### PR TITLE
Fix install deps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.ipynb -linguist-detectable
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true -diff

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ casa-*.log
 # Archive (keep structure but ignore if regenerated)
 archive/
 CLAUDE.md
+# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ gpu = [
     "torchvision>=0.15.0",  # Required for SAM2 image segmentation models
     "transformers>=4.40.0",
     "monai>=1.3.0",
+    "numba>=0.59",  # monai transitive dep; >=0.59 required for Python 3.12
     "kornia",  # GPU-accelerated transforms
     "psutil>=5.9.0",  # Memory monitoring
 ]
@@ -75,8 +76,8 @@ mps = [
 
 # CASA tools for MS handling (always needed)
 casa = [
-    "casatools>=6.5.0",
-    "casatasks>=6.5.0",
+    "casatools>=6.7.0",
+    "casatasks>=6.7.0",
 ]
 
 # Interactive visualization (HoloViz stack for large MS exploration)


### PR DESCRIPTION
samrfi[all] was broken for py3.12 because of an old numba and casatools/tasks dependency. This has now been fixed, and should hopefully be forward compatible as long as casa has a release for that Python version.